### PR TITLE
Fix invitation tree labels

### DIFF
--- a/core/templates/core/user_profile.html
+++ b/core/templates/core/user_profile.html
@@ -107,7 +107,7 @@
         <li class="nav-item">
           <a class="nav-link {% if active_tab == 'davet_aagac' %}active{% endif %}" 
              href="?tab=davet_aagac">
-            Davet Ağaç
+            Davet Ağacı
           </a>
         </li>
         {% endif %}
@@ -197,7 +197,7 @@
         
         <!-- Davet Ağaç Sekmesi -->
         <div class="tab-pane fade {% if active_tab == 'davet_aagac' %}show active{% endif %}" id="davet_aagac" role="tabpanel" aria-labelledby="davet-aagac-tab">
-          <h5>Davet Ağaç</h5>
+          <h5>Davet Ağacı</h5>
           {% if invitation_tree %}
             <div class="invitation-tree">
               <ul class="list-unstyled">


### PR DESCRIPTION
## Summary
- update the "Davet Ağaç" nav text
- update the "Davet Ağaç" section title

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68407f7b4244832f857786033265557b